### PR TITLE
Update UserDefinedValueTypes.sol

### DIFF
--- a/contracts/src/user-defined-value-types/UserDefinedValueTypes.sol
+++ b/contracts/src/user-defined-value-types/UserDefinedValueTypes.sol
@@ -58,7 +58,7 @@ library LibClockBasic {
 }
 
 contract Examples {
-    function example_no_uvdt() external {
+    function example_no_uvdt() external view {
         // Without UDVT
         uint128 clock;
         uint64 d = 1;
@@ -68,7 +68,7 @@ contract Examples {
         clock = LibClockBasic.wrap(t, d);
     }
 
-    function example_uvdt() external {
+    function example_uvdt() external view {
         // Turn value type into user defined value type
         Duration d = Duration.wrap(1);
         Timestamp t = Timestamp.wrap(uint64(block.timestamp));


### PR DESCRIPTION
In User Define Types Contract this should be **external view** otherwise it is giving warning. This updated

```
 function example_no_uvdt() external {
        // Without UDVT
        uint128 clock;
        uint64 d = 1;
        uint64 t = uint64(block.timestamp);
        clock = LibClockBasic.wrap(d, t);
        // Oops! wrong order of inputs but still compiles
        clock = LibClockBasic.wrap(t, d);
    }
```