### PR TITLE
fix: fix the spelling error access decoration formula

### DIFF
--- a/contracts/tests/foundry/auth/AuthTest.sol
+++ b/contracts/tests/foundry/auth/AuthTest.sol
@@ -19,7 +19,7 @@ contract Auth {
 contract AuthTest is Test {
 	Auth private auth;
 
-	function setUp() pubilc {
+	function setUp() public {
 		// owner = this contract
 		auth = new Auth();
 	}


### PR DESCRIPTION
`pubilc`  -->  `public`