### PR TITLE
Fix errors in documentation files

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ solc src/pages/hello-world/HelloWorld.sol
 find src/pages/hacks -name "*.sol" solc {} \;
 find src/pages -type f -name "*.sol" -exec sh -c 'solc "$0"' {} \;
 
-## Mics ##
+## Misc ##
 # rename files
 find . -type f -name "index.test.js" -exec sh -c 'mv "$0" "${0%.test.js}.test.tsx"' {} \;
 ```

--- a/src/pages/call/index.md
+++ b/src/pages/call/index.md
@@ -10,7 +10,7 @@ cyfrinLink: https://www.cyfrin.io/glossary/call-code-example
 
 This is the recommended method to use when you're just sending Ether via calling the `fallback` function.
 
-However it is not the recommend way to call existing functions.
+However it is not the recommended way to call existing functions.
 
 ### Few reasons why low-level call is not recommended
 

--- a/src/pages/defi/vault/index.md
+++ b/src/pages/defi/vault/index.md
@@ -11,9 +11,9 @@ Most vaults on the mainnet are more complex. Here we will focus on the math for 
 
 ### How the contract works
 
-1. Some amount of shares are minted when an user deposits.
+1. Some amount of shares are minted when a user deposits.
 2. The DeFi protocol would use the users' deposits to generate yield (somehow).
-3. User burn shares to withdraw his tokens + yield.
+3. User burns shares to withdraw his tokens + yield.
 
 ```solidity
 {{{Vault}}}

--- a/src/pages/hashing/index.md
+++ b/src/pages/hashing/index.md
@@ -10,7 +10,7 @@ cyfrinLink: https://www.cyfrin.io/glossary/hashing-with-keccak256-code-example
 
 Some use cases are:
 
-- Creating a deterministic unique ID from a input
+- Creating a deterministic unique ID from an input
 - Commit-Reveal scheme
 - Compact cryptographic signature (by signing the hash instead of a larger input)
 


### PR DESCRIPTION
### Summary of Changes

**src/pages/hashing/index.md**
- `Mics ` → `Misc `

**README.md**
- `recommend ` → `recommended `

**src/pages/defi/vault/index.md**
- `an user` → `a user `
- `burn ` → `burns `

**src/pages/hashing/index.md**
- `a input ` → `an input `
