### PR TITLE
fix: typos in documentation files

### DIFF
--- a/src/pages/call/index.md
+++ b/src/pages/call/index.md
@@ -10,7 +10,7 @@ cyfrinLink: https://www.cyfrin.io/glossary/call-solidity-code-example
 
 This is the recommended method to use when you're just sending Ether via calling the `fallback` function.
 
-However it is not the recommend way to call existing functions.
+However it is not the recommended way to call existing functions.
 
 ### Few reasons why low-level call is not recommended
 

--- a/src/pages/enum/index.md
+++ b/src/pages/enum/index.md
@@ -6,7 +6,7 @@ keywords: [data, variable, variables, enum, import, imports]
 cyfrinLink: https://www.cyfrin.io/glossary/enum-solidity-code-example
 ---
 
-Solidity supports enumerables and they are useful to model choice and keep track of state.
+Solidity supports enums and they are useful to model choice and keep track of state.
 
 Enums can be declared outside of a contract.
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected "recommend" to "recommended".

Please review the changes and let me know if any additional changes are needed.