### PR TITLE
Fix: Remove incorrect balance reset in claimReward function inside Self Destruct Forced Prevention Contract

### DIFF
--- a/contracts/src/hacks/self-destruct/PreventForceEther.sol
+++ b/contracts/src/hacks/self-destruct/PreventForceEther.sol
@@ -19,8 +19,9 @@ contract EtherGame {
 
     function claimReward() public {
         require(msg.sender == winner, "Not winner");
+        uint256 amount = balance;
         balance = 0;
-        (bool sent,) = msg.sender.call{value: balance}("");
+        (bool sent,) = msg.sender.call{value: amount}("");
         require(sent, "Failed to send Ether");
     }
 }

--- a/src/pages/hacks/self-destruct/PreventForceEther.sol
+++ b/src/pages/hacks/self-destruct/PreventForceEther.sol
@@ -19,8 +19,9 @@ contract EtherGame {
 
     function claimReward() public {
         require(msg.sender == winner, "Not winner");
+        uint256 amount = balance;
         balance = 0;
-        (bool sent,) = msg.sender.call{value: balance}("");
+        (bool sent,) = msg.sender.call{value: amount}("");
         require(sent, "Failed to send Ether");
     }
 }


### PR DESCRIPTION
## Description
In the Self Destruct Preventative Techniques section, the `claimReward` function contains a logical error where it sets `balance = 0` before attempting to transfer funds. This causes the transfer to fail since it tries to send 0 ETH instead of the actual contract balance.

Current code:
```solidity
function claimReward() public {
    require(msg.sender == winner, "Not winner");
    balance = 0;  // <-- Problem: Sets balance to 0 before transfer
    (bool sent,) = msg.sender.call{value: balance}("");  // Will always try to send 0 ETH
    require(sent, "Failed to send Ether");
}
```

Proposed fix:
```solidity
function claimReward() public {
    require(msg.sender == winner, "Not winner");
    uint256 amount = balance;
    balance = 0;
    (bool sent,) = msg.sender.call{value: amount}("");
    require(sent, "Failed to send Ether");
}
```

## Why this change is necessary
- The current implementation prevents winners from claiming their reward since it tries to transfer 0 ETH
- The fix ensures the proper amount is transferred before resetting the balance
- This aligns with the intended behavior of the game where winners should receive their reward