### PR TITLE
Update FallbackInputOutput.sol

### DIFF
--- a/contracts/src/fallback/FallbackInputOutput.sol
+++ b/contracts/src/fallback/FallbackInputOutput.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
 // TestFallbackInputOutput -> FallbackInputOutput -> Counter


### PR DESCRIPTION
updateded FallbackInputOutput.sol with // SPDX-License-Identifier: MIT because it is giving warning