### PR TITLE
improve the grammatical accuracy of the documentation

### DIFF
--- a/src/pages/call/index.md
+++ b/src/pages/call/index.md
@@ -10,7 +10,7 @@ cyfrinLink: https://www.cyfrin.io/glossary/call-solidity-code-example
 
 This is the recommended method to use when you're just sending Ether via calling the `fallback` function.
 
-However it is not the recommend way to call existing functions.
+However it is not the recommended way to call existing functions.
 
 ### Few reasons why low-level call is not recommended
 

--- a/src/pages/hashing/index.md
+++ b/src/pages/hashing/index.md
@@ -10,7 +10,7 @@ cyfrinLink: https://www.cyfrin.io/glossary/hashing-with-keccak256-solidity-code-
 
 Some use cases are:
 
-- Creating a deterministic unique ID from a input
+- Creating a deterministic unique ID from an input
 - Commit-Reveal scheme
 - Compact cryptographic signature (by signing the hash instead of a larger input)
 


### PR DESCRIPTION
Changes Made
1. In src/pages/call/index.md:
- However it is not the recommend way to call existing functions.
+ However it is not the recommended way to call existing functions.
Reason: The word "recommend" should be "recommended" as it's being used as an adjective in this context. The "-ed" suffix is required for the past participle form.

2. In src/pages/hashing/index.md:
- Creating a deterministic unique ID from a input
+ Creating a deterministic unique ID from an input
Reason: The article "a" should be "an" when it precedes a word that begins with a vowel sound. Since "input" begins with a vowel sound, "an" is the correct article to use.

Summary
These changes improve the grammatical accuracy of the documentation, making it more professional and easier to read. The corrections follow standard English grammar rules regarding:
- Proper use of past participle forms
- Correct article usage before vowel sounds