### PR TITLE
Grammar and Spelling Fixes

### DIFF
--- a/src/pages/data-locations/index.md
+++ b/src/pages/data-locations/index.md
@@ -9,7 +9,7 @@ cyfrinLink: https://www.cyfrin.io/glossary/data-locations-storage-memory-and-cal
 Variables are declared as either `storage`, `memory` or `calldata` to explicitly
 specify the location of the data.
 
-- `storage` - variable is a state variable (store on blockchain)
+- `storage` - variable is a state variable (stored on the blockchain)
 - `memory` - variable is in memory and it exists while a function is being called
 - `calldata` - special data location that contains function arguments
 

--- a/src/pages/delegatecall/index.md
+++ b/src/pages/delegatecall/index.md
@@ -1,7 +1,7 @@
 ---
 title: Delegatecall
 version: 0.8.26
-description: Example of how to use deletegatecall in Solidity
+description: Example of how to use delegatecall in Solidity
 keywords: [delegatecall, call, contract, contracts, function, functions]
 cyfrinLink: https://www.cyfrin.io/glossary/delegatecall-solidity-code-example
 ---

--- a/src/pages/tests/echidna/index.md
+++ b/src/pages/tests/echidna/index.md
@@ -24,7 +24,7 @@ Inside docker, your code will be stored at `/code`, in the root directory.
 
 ### Testing Time and Sender
 
-Echidna can fuzz timestamp. Range of timestamp is set in the configuration. Default is 7 days.
+Echidna can fuzz timestamps. Range of timestamp is set in the configuration. Default is 7 days.
 
 Contract callers can also be set in the configuration. Default accounts are
 


### PR DESCRIPTION

This PR fixes several grammatical and spelling issues across multiple files to improve documentation clarity.

## Changes Made:

### 1. src/pages/data-locations/index.md
- Old: "store on blockchain"
- New: "stored on the blockchain"
Reason: Added past participle form and the definite article for grammatical correctness.

### 2. src/pages/delegatecall/index.md
- Old: "deletegatecall"
- New: "delegatecall"
Reason: Fixed spelling error in the description metadata.

### 3. src/pages/tests/echidna/index.md
- Old: "timestamp" (singular)
- New: "timestamps" (plural)
Reason: Used plural form for consistency since we're referring to multiple timestamp values.

These changes improve the readability and professional appearance of the documentation while maintaining technical accuracy. The modifications focus on proper grammar, correct spelling, and consistent terminology usage throughout the codebase.

