### PR TITLE
Fix Grammar and Article Usage in Vault and Hashing Documentation

### DIFF
--- a/src/pages/defi/vault/index.md
+++ b/src/pages/defi/vault/index.md
@@ -11,7 +11,7 @@ Most vaults on the mainnet are more complex. Here we will focus on the math for 
 
 ### How the contract works
 
-1. Some amount of shares are minted when an user deposits.
+1. Some amount of shares are minted when a user deposits.
 2. The DeFi protocol would use the users' deposits to generate yield (somehow).
 3. User burn shares to withdraw his tokens + yield.
 

--- a/src/pages/hashing/index.md
+++ b/src/pages/hashing/index.md
@@ -10,7 +10,7 @@ cyfrinLink: https://www.cyfrin.io/glossary/hashing-with-keccak256-solidity-code-
 
 Some use cases are:
 
-- Creating a deterministic unique ID from a input
+- Creating a deterministic unique ID from an input
 - Commit-Reveal scheme
 - Compact cryptographic signature (by signing the hash instead of a larger input)
 


### PR DESCRIPTION
This pull request addresses grammatical issues and article usage improvements in the documentation:

1. In `index.md` (Vault), changed "an user" to "a user" for proper article usage.
2. In `index.md` (Hashing), corrected "a input" to "an input" for proper article usage.

These changes enhance clarity and correctness in the documentation.
