### PR TITLE
Added flowchart to explain fallback and receive function logic

### DIFF
--- a/src/pages/fallback/index.md
+++ b/src/pages/fallback/index.md
@@ -11,6 +11,22 @@ cyfrinLink: https://www.cyfrin.io/glossary/fallback-solidity-code-example
 - a function that does not exist is called or
 - Ether is sent directly to a contract but `receive()` does not exist or `msg.data` is not empty
 
+To better understand the conditions under which Solidity calls the receive or fallback function, refer to the flowchart below:
+
+```
+                 send Ether
+                      |
+           msg.data is empty?
+                /           \
+            yes             no
+             |                |
+    receive() exists?     fallback()
+        /        \
+     yes          no
+      |            |
+  receive()     fallback()
+```
+  
 `fallback` has a 2300 gas limit when called by `transfer` or `send`.
 
 ```solidity

--- a/src/pages/fallback/index.md
+++ b/src/pages/fallback/index.md
@@ -11,7 +11,7 @@ cyfrinLink: https://www.cyfrin.io/glossary/fallback-solidity-code-example
 - a function that does not exist is called or
 - Ether is sent directly to a contract but `receive()` does not exist or `msg.data` is not empty
 
-To better understand the conditions under which Solidity calls the receive or fallback function, refer to the flowchart below:
+To better understand the conditions under which Solidity calls the `receive` or `fallback` function, refer to the flowchart below:
 
 ```
                  send Ether


### PR DESCRIPTION
* Added a flowchart to the `src/pages/fallback/index.md` file to help understand the conditions under which Solidity calls the `receive` or `fallback` function.

The flowchart breaks it down step by step:

It shows that if Ether is sent without data, Solidity checks if a receive function exists and calls it.
If Ether is sent with data, or if the receive function doesn’t exist, the fallback function is called.
By adding this diagram, it’s easier for beginners to understand how Solidity handles incoming Ether, especially when the explanation in text might feel too abstract. The flowchart is placed right after the explanation of receive to provide a visual aid before jumping into the code examples.

This contribution makes the documentation more beginner-friendly and accessible.

