### PR TITLE
Update `supportsInterface` Mutability to `pure`

### DIFF
--- a/contracts/src/app/erc1155/ERC1155.sol
+++ b/contracts/src/app/erc1155/ERC1155.sol
@@ -157,7 +157,7 @@ contract ERC1155 is IERC1155 {
     // ERC165
     function supportsInterface(bytes4 interfaceId)
         external
-        view
+        pure
         returns (bool)
     {
         return interfaceId == 0x01ffc9a7 // ERC165 Interface ID for ERC165


### PR DESCRIPTION
# PR Description: Update `supportsInterface` Mutability to `pure`

## Summary

This PR updates the `supportsInterface` function in the contract to use the `pure` mutability specifier instead of `view`. The change reflects the actual behavior of the function, aligns with Solidity's best practices, and addresses a compiler warning without altering the functionality or breaking EIP-165 compliance.

---

## Background

In the [EIP-165 example implementation](https://eips.ethereum.org/EIPS/eip-165), the `supportsInterface` function is marked as `view` because it reads from a `mapping`:

```solidity
mapping(bytes4 => bool) internal supportedInterfaces;

function supportsInterface(bytes4 interfaceID) external view returns (bool) {
    return supportedInterfaces[interfaceID];
}
```

Here, the view mutability is required since the function accesses blockchain storage (supportedInterfaces). However, in our implementation, the function does not interact with storage:

```solidity
function supportsInterface(bytes4 interfaceId)
    external
    view
    returns (bool)
{
    return interfaceId == 0x01ffc9a7 // ERC165 Interface ID for ERC165
        || interfaceId == 0xd9b67a26 // ERC165 Interface ID for ERC1155
        || interfaceId == 0x0e89341c; // ERC165 Interface ID for ERC1155MetadataURI
}
```

The function performs a simple computation by comparing the input interfaceId to predefined constants, which qualifies it as pure.

## Why the Change is Needed

### Function Behavior
The `supportsInterface` function in our code does not interact with blockchain storage or state. Declaring it as `pure` better reflects its stateless nature.

### EIP-165 Compliance
EIP-165 requires the function to avoid modifying state, which is satisfied by both `pure` and `view`. Switching to `pure` does not affect compliance.

### Compiler Warning
Solidity warns when a `view` function does not actually read state. This change eliminates the warning and adheres to best practices.

### Code Clarity
Marking the function as `pure` explicitly communicates its independence from blockchain state, improving readability and maintainability.

---

## Impact of the Change
- **Non-Breaking**: This change does not alter the function's behavior or external interface.
- **Improves Code Quality**: Aligns with Solidity's recommendations and removes unnecessary warnings.
- **Fully EIP-165 Compliant**: The function remains callable without modifying blockchain state.

---
