### PR TITLE
Add comparison between call and delegatecall in contract A

### DIFF
--- a/contracts/src/delegatecall/Delegatecall.sol
+++ b/contracts/src/delegatecall/Delegatecall.sol
@@ -21,13 +21,28 @@ contract A {
     uint256 public value;
 
     event DelegateResponse(bool success, bytes data);
+    event CallResponse(bool success, bytes data);
 
-    function setVars(address _contract, uint256 _num) public payable {
-        // A's storage is set, B is not modified.
+    // Function using delegatecall
+    function setVarsDelegateCall(address _contract, uint256 _num)
+        public
+        payable
+    {
+        // A's storage is set; B's storage is not modified.
         (bool success, bytes memory data) = _contract.delegatecall(
             abi.encodeWithSignature("setVars(uint256)", _num)
         );
 
         emit DelegateResponse(success, data);
+    }
+
+    // Function using call
+    function setVarsCall(address _contract, uint256 _num) public payable {
+        // B's storage is set; A's storage is not modified.
+        (bool success, bytes memory data) = _contract.call{value: msg.value}(
+            abi.encodeWithSignature("setVars(uint256)", _num)
+        );
+
+        emit CallResponse(success, data);
     }
 }


### PR DESCRIPTION
This PR adds a new function `setVarsCall` in contract A to demonstrate the difference between `delegatecall` and `call`