### PR TITLE
Fix Grammar Issues in Comments

### DIFF
--- a/src/pages/events/Events.sol
+++ b/src/pages/events/Events.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.26;
 contract Event {
     // Event declaration
     // Up to 3 parameters can be indexed.
-    // Indexed parameters helps you filter the logs by the indexed parameter
+    // Indexed parameters help you filter the logs by the indexed parameter
     event Log(address indexed sender, string message);
     event AnotherLog();
 

--- a/src/pages/gas/Gas.sol
+++ b/src/pages/gas/Gas.sol
@@ -6,7 +6,7 @@ contract Gas {
 
     // Using up all of the gas that you send causes your transaction to fail.
     // State changes are undone.
-    // Gas spent are not refunded.
+    // Gas spent is not refunded.
     function forever() public {
         // Here we run a loop until all of the gas are spent
         // and the transaction fails


### PR DESCRIPTION


1. In src/pages/gas/Gas.sol:
Old: // Gas spent are not refunded.
New: // Gas spent is not refunded.
Reason: "Gas spent" is treated as a singular noun phrase requiring singular verb "is"

2. In src/pages/events/Events.sol:
Old: // Indexed parameters helps you filter the logs
New: // Indexed parameters help you filter the logs
Reason: "Parameters" is plural requiring plural verb "help"
