### PR TITLE
Fix: Typos in documentation

### DIFF
--- a/contracts/src/hacks/front-running/PreventFrontRunning.sol
+++ b/contracts/src/hacks/front-running/PreventFrontRunning.sol
@@ -9,7 +9,7 @@ pragma solidity ^0.8.26;
 1. Alice deploys SecuredFindThisHash with 10 Ether.
 2. Bob finds the correct string that will hash to the target hash. ("Ethereum").
 3. Bob then finds the keccak256(Address in lowercase + Solution + Secret). 
-   Address is his wallet address in lowercase, solution is "Ethereum", Secret is like an password ("mysecret") 
+   Address is his wallet address in lowercase, solution is "Ethereum", Secret is like a password ("mysecret") 
    that only Bob knows which Bob uses to commit and reveal the solution.
    keccak2566("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266Ethereummysecret") = '0xf95b1dd61edc3bd962cdea3987c6f55bcb714a02a2c3eb73bd960d6b4387fc36'
 3. Bob then calls commitSolution("0xf95b1dd61edc3bd962cdea3987c6f55bcb714a02a2c3eb73bd960d6b4387fc36"), 
@@ -92,7 +92,7 @@ contract SecuredFindThisHash {
     /* 
         Function to reveal the commit and get the reward. 
         Users can get reveal solution only if the game is active and they have committed a solutionHash before this block and not revealed yet.
-        It generates an keccak256(msg.sender + solution + secret) and checks it with the previously committed hash.  
+        It generates a keccak256(msg.sender + solution + secret) and checks it with the previously committed hash.  
         Assuming that a commit was already included on chain, front runners will not be able to pass this check since the msg.sender is different.
         Then the actual solution is checked using keccak256(solution), if the solution matches, the winner is declared, 
         the game is ended and the reward amount is sent to the winner.

--- a/src/pages/hacks/front-running/PreventFrontRunning.sol
+++ b/src/pages/hacks/front-running/PreventFrontRunning.sol
@@ -9,7 +9,7 @@ pragma solidity ^0.8.26;
 1. Alice deploys SecuredFindThisHash with 10 Ether.
 2. Bob finds the correct string that will hash to the target hash. ("Ethereum").
 3. Bob then finds the keccak256(Address in lowercase + Solution + Secret). 
-   Address is his wallet address in lowercase, solution is "Ethereum", Secret is like an password ("mysecret") 
+   Address is his wallet address in lowercase, solution is "Ethereum", Secret is like a password ("mysecret") 
    that only Bob knows which Bob uses to commit and reveal the solution.
    keccak2566("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266Ethereummysecret") = '0xf95b1dd61edc3bd962cdea3987c6f55bcb714a02a2c3eb73bd960d6b4387fc36'
 3. Bob then calls commitSolution("0xf95b1dd61edc3bd962cdea3987c6f55bcb714a02a2c3eb73bd960d6b4387fc36"), 
@@ -92,7 +92,7 @@ contract SecuredFindThisHash {
     /* 
         Function to reveal the commit and get the reward. 
         Users can get reveal solution only if the game is active and they have committed a solutionHash before this block and not revealed yet.
-        It generates an keccak256(msg.sender + solution + secret) and checks it with the previously committed hash.  
+        It generates a keccak256(msg.sender + solution + secret) and checks it with the previously committed hash.  
         Assuming that a commit was already included on chain, front runners will not be able to pass this check since the msg.sender is different.
         Then the actual solution is checked using keccak256(solution), if the solution matches, the winner is declared, 
         the game is ended and the reward amount is sent to the winner.


### PR DESCRIPTION
This PR fixes typos in the `PreventFrontRunning.sol` file and its associated documentation. Specifically:

1. Corrected "an password" to "a password."
2. Improved wording consistency in the explanation of `keccak256` hash generation.

These changes enhance the readability and professionalism of the contract's inline documentation and related content.

---

## Changes Made

- Corrected grammatical typos in **contracts/src/hacks/front-running/PreventFrontRunning.sol**.
- Updated corresponding text in **src/pages/hacks/front-running/PreventFrontRunning.sol**.

---

## Checklist

I have:

- [x] Ensured all changes are clear and improve the documentation.
- [x] Linked this PR to the correct branch.
- [x] Targeted only one GitHub issue (if applicable).
- [x] Checked that all CI tests pass.
- [x] Reviewed and updated relevant documentation.