### PR TITLE
 documentation clarity 

### DIFF
--- a/contracts/src/import/Import.sol
+++ b/contracts/src/import/Import.sol
@@ -11,7 +11,7 @@ contract Import {
     // Initialize Foo.sol
     Foo public foo = new Foo();
 
-    // Test Foo.sol by getting it's name.
+    // Test Foo.sol by getting its name.
     function getFooName() public view returns (string memory) {
         return foo.name();
     }

--- a/src/pages/import/Import.sol
+++ b/src/pages/import/Import.sol
@@ -11,7 +11,7 @@ contract Import {
     // Initialize Foo.sol
     Foo public foo = new Foo();
 
-    // Test Foo.sol by getting it's name.
+    // Test Foo.sol by getting its name.
     function getFooName() public view returns (string memory) {
         return foo.name();
     }


### PR DESCRIPTION
The word "it's" is a contraction meaning "it is" or "it has", while "its" is the possessive form of "it". In this context, we are referring to the possessive form - the name belonging to Foo.sol, so "its" is the correct usage.
This change improves code documentation clarity and maintains proper English grammar in comments.