### PR TITLE
Fix spelling

### DIFF
--- a/src/pages/app/crowd-fund/index.md
+++ b/src/pages/app/crowd-fund/index.md
@@ -1,7 +1,7 @@
 ---
 title: Crowd Fund
 version: 0.8.26
-description: An example of crowd funding contract
+description: An example of crowdfunding contract
 keywords: [app, application, crowd, fund, funding]
 cyfrinLink: https://www.cyfrin.io/glossary/crowd-fund-solidity-code-example
 ---

--- a/src/pages/app/crowd-fund/index.md
+++ b/src/pages/app/crowd-fund/index.md
@@ -11,7 +11,7 @@ Crowd fund ERC20 token
 1. User creates a campaign.
 2. Users can pledge, transferring their token to a campaign.
 3. After the campaign ends, campaign creator can claim the funds if total amount pledged is more than the campaign goal.
-4. Otherwise, campaign did not reach it's goal, users can withdraw their pledge.
+4. Otherwise, campaign did not reach its goal, users can withdraw their pledge.
 
 ```solidity
 {{{CrowdFund}}}

--- a/src/pages/app/erc721/index.md
+++ b/src/pages/app/erc721/index.md
@@ -1,7 +1,7 @@
 ---
 title: ERC721
 version: 0.8.26
-description: Example of ERC721 non fungible token in Solidity
+description: Example of ERC721 non-fungible token in Solidity
 keywords: [app, application, erc721, ierc721, nft]
 cyfrinLink: https://www.cyfrin.io/glossary/erc-721-solidity-code-example
 ---


### PR DESCRIPTION
Fixed spelling errors in the `index.md` files:

- Changed "crowd fund" to "crowdfunding"
- Corrected "non fungible" to "non-fungible"
- Fixed "it's" to "its" in the context of the campaign goal