### PR TITLE
Adding abi.encode and abi.encodePacked differences

### DIFF
--- a/src/pages/hashing/index.md
+++ b/src/pages/hashing/index.md
@@ -14,6 +14,20 @@ Some use cases are:
 - Commit-Reveal scheme
 - Compact cryptographic signature (by signing the hash instead of a larger input)
 
+
+Solidity provides two methods for encoding data:
+
+- `abi.encode`: 
+   - Encodes data into bytes with padding
+   - Preserves all data information
+   - Safer when dealing with dynamic types
+   - Produces a longer output due to padding
+- `abi.encodePacked`:
+   - Performs packed encoding (compressed)
+   - Produces a shorter output than `abi.encode`
+   - More gas efficient
+   - Risk of hash collisions with dynamic types (`collision` function)
+
 ```solidity
 {{{Keccak256}}}
 ```


### PR DESCRIPTION
I encountered a gap in my memory and, while searching for an example, I opened the page expecting to find an encode example or at least an explanation. Since it was missing, I added a section that would have helped me and could benefit others in a similar situation.