### PR TITLE
Grammar and Clarity Fixes

### DIFF
--- a/src/pages/array/index.md
+++ b/src/pages/array/index.md
@@ -6,21 +6,21 @@ keywords: [data, variable, variables, array, arrays]
 cyfrinLink: https://www.cyfrin.io/glossary/array-solidity-code-example
 ---
 
-Array can have a compile-time fixed size or a dynamic size.
+An array can have a compile-time fixed size or a dynamic size.
 
 ```solidity
 {{{Array}}}
 ```
 
-### Examples of removing array element
+### Examples of removing an array element
 
-Remove array element by shifting elements from right to left
+Remove an array element by shifting elements from right to left
 
 ```solidity
 {{{ArrayRemoveByShifting}}}
 ```
 
-Remove array element by copying last element into to the place to remove
+Remove an array element by copying last element into to the place to remove
 
 ```solidity
 {{{ArrayReplaceFromEnd}}}

--- a/src/pages/gas-golf/GasGolf.sol
+++ b/src/pages/gas-golf/GasGolf.sol
@@ -10,7 +10,7 @@ contract GasGolf {
     // loop increments - 48244 gas
     // cache array length - 48209 gas
     // load array elements to memory - 48047 gas
-    // uncheck i overflow/underflow - 47309 gas
+    // unchecked i overflow/underflow - 47309 gas
 
     uint256 public total;
 

--- a/src/pages/gas/index.html.ts
+++ b/src/pages/gas/index.html.ts
@@ -39,7 +39,7 @@ const html = `<h3>How much <code>ether</code> do you need to pay for a transacti
     <span class="hljs-comment">// State changes are undone.</span>
     <span class="hljs-comment">// Gas spent is not refunded.</span>
     <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">forever</span>(<span class="hljs-params"></span>) <span class="hljs-title"><span class="hljs-keyword">public</span></span> </span>{
-        <span class="hljs-comment">// Here we run a loop until all of the gas are spent</span>
+        <span class="hljs-comment">// Here we run a loop until all of the gas is spent</span>
         <span class="hljs-comment">// and the transaction fails</span>
         <span class="hljs-keyword">while</span> (<span class="hljs-literal">true</span>) {
             i <span class="hljs-operator">+</span><span class="hljs-operator">=</span> <span class="hljs-number">1</span>;


### PR DESCRIPTION
Documentation Text:

Old:
Array can have a compile-time fixed size or a dynamic size.
New:
An array can have a compile-time fixed size or a dynamic size.
Reason:
Added the article "An" for correct grammar when referring to a singular, countable noun.
Solidity Code Comment (Gas Contract):

Old:
// uncheck i overflow/underflow - 47309 gas
New:
// unchecked i overflow/underflow - 47309 gas
Reason:
Corrected "uncheck" to "unchecked" to properly describe the unchecked arithmetic operation in Solidity.
HTML Code Comment:

Old:
<span class="hljs-comment">// Here we run a loop until all of the gas are spent</span>
New:
<span class="hljs-comment">// Here we run a loop until all of the gas is spent</span>
Reason:
Changed "are spent" to "is spent" because "gas" is an uncountable noun, and the singular verb form is required.