### PR TITLE
documentation clarity

### DIFF
--- a/src/pages/defi/constant-sum-amm/CSAMM.sol
+++ b/src/pages/defi/constant-sum-amm/CSAMM.sol
@@ -13,7 +13,7 @@ contract CSAMM {
 
     constructor(address _token0, address _token1) {
         // NOTE: This contract assumes that token0 and token1
-        // both have same decimals
+        // both have the same decimals
         token0 = IERC20(_token0);
         token1 = IERC20(_token1);
     }

--- a/src/pages/defi/staking-rewards/index.html.ts
+++ b/src/pages/defi/staking-rewards/index.html.ts
@@ -16,7 +16,7 @@ export const codes = [
 ]
 
 const html = `<p>This is a minimal example of a contract that rewards users for staking their token.</p>
-<p>Code is a stripped down version of Synthetix <a href="https://github.com/Synthetixio/synthetix/blob/develop/contracts/StakingRewards.sol" target="__blank">StakingRewards.sol</a></p>
+<p>Code is a stripped down version of Synthetix <a href="https://github.com/Synthetixio/synthetix/blob/develop/contracts/StakingRewards.sol" target="_blank">StakingRewards.sol</a></p>
 <h3>Staking Rewards</h3>
 <pre><code class="language-solidity"><span class="hljs-comment">// SPDX-License-Identifier: MIT</span>
 <span class="hljs-meta"><span class="hljs-keyword">pragma</span> <span class="hljs-keyword">solidity</span> ^0.8.26;</span>

--- a/src/pages/ether-units/index.md
+++ b/src/pages/ether-units/index.md
@@ -8,7 +8,7 @@ cyfrinLink: https://www.cyfrin.io/glossary/ether-and-wei-solidity-code-example
 
 Transactions are paid with `ether`.
 
-Similar to how one dollar is equal to 100 cent, one `ether` is equal to 10<sup>18</sup> `wei`.
+Similar to how one dollar is equal to 100 cents, one `ether` is equal to 10<sup>18</sup> `wei`.
 
 ```solidity
 {{{EtherUnits}}}

--- a/src/pages/evm/memory/YulMem.sol
+++ b/src/pages/evm/memory/YulMem.sol
@@ -14,7 +14,7 @@ pragma solidity 0.8.26;
 // Free memory pointer (0x40)
 // 0x80 = Free memory pointer initially points here
 contract MemBasic {
-    // mstore(p, v) = store 32 bytes to memory starting at memory location p
+    // mstore(p, v) = stored 32 bytes to memory starting at memory location p
     // mload(p) = load 32 bytes from memory starting at memory location p
     function test_1() public pure returns (bytes32 b32) {
         assembly {

--- a/src/pages/evm/memory/index.md
+++ b/src/pages/evm/memory/index.md
@@ -18,6 +18,6 @@ Examples of
 
 ### References
 
-[Solidity document](https://docs.soliditylang.org/en/latest/internals/layout_in_memory.html)
+[Solidity documentation](https://docs.soliditylang.org/en/latest/internals/layout_in_memory.html)
 
 [EVM Codes](https://www.evm.codes/)

--- a/src/pages/function-selector/index.md
+++ b/src/pages/function-selector/index.md
@@ -10,7 +10,7 @@ When a function is called, the first 4 bytes of `calldata` specifies which funct
 
 This 4 bytes is called a function selector.
 
-Take for example, this code below. It uses `call` to execute `transfer` on a contract at the address `addr`.
+Take, for example, this code below. It uses `call` to execute `transfer` on a contract at the address `addr`.
 
 ```solidity
 addr.call(abi.encodeWithSignature("transfer(address,uint256)", 0xSomeAddress, 123))


### PR DESCRIPTION

have same > have the same
__blank > _blank
100 cent > 100 cents
store > stored
Solidity document > Solidity documentation
Take for example, > Take, for example,