### PR TITLE
Fix grammatical errors in documentation and comments

### DIFF
--- a/src/pages/app/multi-sig-wallet/index.md
+++ b/src/pages/app/multi-sig-wallet/index.md
@@ -12,7 +12,7 @@ The wallet owners can
 
 - submit a transaction
 - approve and revoke approval of pending transactions
-- anyone can execute a transaction after enough owners has approved it.
+- anyone can execute a transaction after enough owners have approved it.
 
 ```solidity
 {{{MultiSigWallet}}}

--- a/src/pages/app/time-lock/TimeLock.sol
+++ b/src/pages/app/time-lock/TimeLock.sol
@@ -63,7 +63,7 @@ contract TimeLock {
      * @param _target Address of contract or account to call
      * @param _value Amount of ETH to send
      * @param _func Function signature, for example "foo(address,uint256)"
-     * @param _data ABI encoded data send.
+     * @param _data ABI-encoded data to send.
      * @param _timestamp Timestamp after which the transaction can be executed.
      */
     function queue(


### PR DESCRIPTION
Corrected subject-verb agreement ("has" → "have") to match the plural subject "owners."

Improved grammar and clarity by adding a hyphen to "ABI-encoded" and fixing "data send" → "data to send."