### PR TITLE
Fix keccak256 typo in EVMStorage contract comments

### DIFF
--- a/contracts/src/evm/storage/EVMStorage.sol
+++ b/contracts/src/evm/storage/EVMStorage.sol
@@ -428,7 +428,7 @@ contract EVMStorageDynamicArray {
 }
 
 contract EVMStorageMapping {
-    // slot of value = keccack256(key, slot where mapping is declared)
+    // slot of value = keccak256(key, slot where mapping is declared)
     mapping(address => uint256) public map;
 
     address public constant ADDR_1 = address(1);
@@ -453,7 +453,7 @@ contract EVMStorageMapping {
 
 contract EVMStorageNestedMapping {
     // key0 => key1 => val
-    // slot of value = keccak256(key1, keccack256(key0, slot where nested mapping is declared))
+    // slot of value = keccak256(key1, keccak256(key0, slot where nested mapping is declared))
     mapping(address => mapping(address => uint256)) public map;
 
     address public constant ADDR_1 = address(1);

--- a/src/pages/evm/storage/EVMStorage.sol
+++ b/src/pages/evm/storage/EVMStorage.sol
@@ -428,7 +428,7 @@ contract EVMStorageDynamicArray {
 }
 
 contract EVMStorageMapping {
-    // slot of value = keccack256(key, slot where mapping is declared)
+    // slot of value = keccak256(key, slot where mapping is declared)
     mapping(address => uint256) public map;
 
     address public constant ADDR_1 = address(1);
@@ -453,7 +453,7 @@ contract EVMStorageMapping {
 
 contract EVMStorageNestedMapping {
     // key0 => key1 => val
-    // slot of value = keccak256(key1, keccack256(key0, slot where nested mapping is declared))
+    // slot of value = keccak256(key1, keccak256(key0, slot where nested mapping is declared))
     mapping(address => mapping(address => uint256)) public map;
 
     address public constant ADDR_1 = address(1);

--- a/src/pages/evm/storage/index.html.ts
+++ b/src/pages/evm/storage/index.html.ts
@@ -457,7 +457,7 @@ const html = `<p>Examples of</p>
 }
 
 <span class="hljs-class"><span class="hljs-keyword">contract</span> <span class="hljs-title">EVMStorageMapping</span> </span>{
-    <span class="hljs-comment">// slot of value = keccack256(key, slot where mapping is declared)</span>
+    <span class="hljs-comment">// slot of value = keccak256(key, slot where mapping is declared)</span>
     <span class="hljs-keyword">mapping</span>(<span class="hljs-keyword">address</span> <span class="hljs-operator">=</span><span class="hljs-operator">&gt;</span> <span class="hljs-keyword">uint256</span>) <span class="hljs-keyword">public</span> map;
 
     <span class="hljs-keyword">address</span> <span class="hljs-keyword">public</span> <span class="hljs-keyword">constant</span> ADDR_1 <span class="hljs-operator">=</span> <span class="hljs-keyword">address</span>(<span class="hljs-number">1</span>);
@@ -482,7 +482,7 @@ const html = `<p>Examples of</p>
 
 <span class="hljs-class"><span class="hljs-keyword">contract</span> <span class="hljs-title">EVMStorageNestedMapping</span> </span>{
     <span class="hljs-comment">// key0 =&gt; key1 =&gt; val</span>
-    <span class="hljs-comment">// slot of value = keccak256(key1, keccack256(key0, slot where nested mapping is declared))</span>
+    <span class="hljs-comment">// slot of value = keccak256(key1, keccak256(key0, slot where nested mapping is declared))</span>
     <span class="hljs-keyword">mapping</span>(<span class="hljs-keyword">address</span> <span class="hljs-operator">=</span><span class="hljs-operator">&gt;</span> <span class="hljs-keyword">mapping</span>(<span class="hljs-keyword">address</span> <span class="hljs-operator">=</span><span class="hljs-operator">&gt;</span> <span class="hljs-keyword">uint256</span>)) <span class="hljs-keyword">public</span> map;
 
     <span class="hljs-keyword">address</span> <span class="hljs-keyword">public</span> <span class="hljs-keyword">constant</span> ADDR_1 <span class="hljs-operator">=</span> <span class="hljs-keyword">address</span>(<span class="hljs-number">1</span>);


### PR DESCRIPTION
Updates incorrect spelling of "keccak256" in comments within the EVMStorage contract.

Changes:
- Fixed typo "keccack256" to "keccak256" in mapping storage slot comments
- Updated both EVMStorageMapping and EVMStorageNestedMapping contracts
- Maintains consistent spelling throughout the codebase

This is a documentation-only change that improves code readability and consistency.